### PR TITLE
REL-872 | Do not process expired messages to the DLQ

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,7 +29,6 @@ default['activemq']['wrapper']['truststore_path'] = '%ACTIVEMQ_CONF%/broker.ts'
 
 default['activemq']['enabled'] = true
 default['activemq']['enable_stomp'] = true
-default['activemq']['dlq_process_expired'] = false
 default['activemq']['enable_broker_statistics'] = true
 default['activemq']['use_default_config'] = false
 default['activemq']['install_java'] = true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,6 +29,7 @@ default['activemq']['wrapper']['truststore_path'] = '%ACTIVEMQ_CONF%/broker.ts'
 
 default['activemq']['enabled'] = true
 default['activemq']['enable_stomp'] = true
+default['activemq']['dlq_process_expired'] = false
 default['activemq']['enable_broker_statistics'] = true
 default['activemq']['use_default_config'] = false
 default['activemq']['install_java'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Installs activemq and sets it up as service'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.0.1005'
+version '2.0.1006'
 
 recipe 'activemq::default', 'Installs Apache ActiveMQ and sets up the service using the included init script.'
 

--- a/templates/default/activemq.xml.erb
+++ b/templates/default/activemq.xml.erb
@@ -38,7 +38,7 @@
         The <broker> element is used to configure the ActiveMQ broker.
     -->
     <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.data}">
-        <% if node['activemq']['enable_broker_statistics'] -%> 
+        <% if node['activemq']['enable_broker_statistics'] -%>
         <plugins>
           <statisticsBrokerPlugin/>
         </plugins>
@@ -59,6 +59,19 @@
                     <constantPendingMessageLimitStrategy limit="1000"/>
                   </pendingMessageLimitStrategy>
                 </policyEntry>
+      <% unless node['activemq']['dlq_process_expired'] -%>
+      <!-- Set the following policy on all queues using the '>' wildcard -->
+                <policyEntry queue=">">
+                 <!--
+                   Tell the dead letter strategy not to process expired messages
+                   so that they will just be discarded instead of being sent to
+                   the DLQ
+                 -->
+                 <deadLetterStrategy>
+                   <sharedDeadLetterStrategy processExpired="false" />
+                 </deadLetterStrategy>
+               </policyEntry>
+      <% end -%>
               </policyEntries>
             </policyMap>
         </destinationPolicy>
@@ -121,7 +134,7 @@
               %>maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
             <transportConnector name="amqp" uri="amqp://0.0.0.0:5672?maximumConnections=1000&amp;wireFormat.maxFrameSize=104857600"/>
 <% if node['activemq']['enable_stomp'] -%>
-            <transportConnector name="stomp" uri="stomp://0.0.0.0:61613?<%= 
+            <transportConnector name="stomp" uri="stomp://0.0.0.0:61613?<%=
               node['activemq']['transport_protocols'] ?
                 "transport.enabledProtocols=#{node['activemq']['transport_protocols']}&amp;" :
                 ''

--- a/templates/default/activemq.xml.erb
+++ b/templates/default/activemq.xml.erb
@@ -59,19 +59,15 @@
                     <constantPendingMessageLimitStrategy limit="1000"/>
                   </pendingMessageLimitStrategy>
                 </policyEntry>
-      <% unless node['activemq']['dlq_process_expired'] -%>
       <!-- Set the following policy on all queues using the '>' wildcard -->
                 <policyEntry queue=">">
                  <!--
-                   Tell the dead letter strategy not to process expired messages
-                   so that they will just be discarded instead of being sent to
-                   the DLQ
+                    Expire the messages from the dlq after a set time 
                  -->
                  <deadLetterStrategy>
-                   <sharedDeadLetterStrategy processExpired="false" />
+                   <sharedDeadLetterStrategy expiration="604800000" processExpired="true"  processNonPersistent="true" />
                  </deadLetterStrategy>
                </policyEntry>
-      <% end -%>
               </policyEntries>
             </policyMap>
         </destinationPolicy>


### PR DESCRIPTION
### Description

Added the option to stop processing expired messages to the DLQ. Failed messages, if any, will still be processed into the DLQ. 

