### PR TITLE
REL-989 Prune inactive queues. Set low prefetch and high expiry pagesize for …

### DIFF
--- a/templates/default/activemq.xml.erb
+++ b/templates/default/activemq.xml.erb
@@ -37,7 +37,7 @@
     <!--
         The <broker> element is used to configure the ActiveMQ broker.
     -->
-    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.data}">
+    <broker xmlns="http://activemq.apache.org/schema/core" brokerName="localhost" dataDirectory="${activemq.data}" schedulePeriodForDestinationPurge="600000">
         <% if node['activemq']['enable_broker_statistics'] -%>
         <plugins>
           <statisticsBrokerPlugin/>
@@ -59,13 +59,15 @@
                     <constantPendingMessageLimitStrategy limit="1000"/>
                   </pendingMessageLimitStrategy>
                 </policyEntry>
-                <policyEntry queue=">" >
+                <policyEntry queue=">" gcInactiveDestinations="true" inactiveTimeoutBeforeGC="259200000" >
                 <!--
                    Expire the message from the dlq
                  -->
                  <deadLetterStrategy>
                    <sharedDeadLetterStrategy expiration="604800000" processExpired="true" processNonPersistent="true" />
                  </deadLetterStrategy>
+                </policyEntry>
+                <policyEntry queue="Consumer.derive.VirtualTopic.entities" queuePrefetch="1" maxExpirePageSize="4000">
                 </policyEntry>
               </policyEntries>
             </policyMap>


### PR DESCRIPTION
…derive queue.

### Description
Auto prune queues that have had no messages and no consumers connected for 3 days. Check every 10 minutes for such queues.
For the derive queue, set prefetch to 1 and increase expire page size to 4000.
### Issues Resolved
Trying to prevent the slow derive queue from filling up the AMQ store with un-expired messages, and also to clean up all of our old abandoned queues.
